### PR TITLE
[fix]ログイン後のヘッダー要素テストを修正

### DIFF
--- a/app/views/layouts/_login_header.html.erb
+++ b/app/views/layouts/_login_header.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-md bg-white rounded-bottom fixed-top py-0">
   <div class="container">
     <%= link_to root_path, class: "navbar-brand" do %>
-      <%= image_tag 'skill_barter_logo.jpg', width: 70, height: 70 %>
+      <%= image_tag 'skill_barter_logo.jpg', width: 70, height: 70, alt: "skill_barter_logo" %>
     <% end %>
 
     <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#Navbar" aria-controls="Navbar" aria-expanded="false" aria-label="ナビゲーションの切替">

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock "~> 3.14.0"
 
 set :application, "SKILL-BARTER"
-set :repo_url, "git@github.com:utkazu/SKILL-BARTER.git"
+set :repo_url, "git@github.com:ASamuraiS619/SKILL-BARTER.git"
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     phone_number { Faker::PhoneNumber.cell_phone.delete("-") }
     introduction { Faker::Lorem.characters(number: 30) }
     profile_image_id { Faker::Lorem.characters(number: 30) }
-    user_status { rand(1..2) }
+    user_status { 1 }
     email { Faker::Internet.email }
     password { 'password' }
     password_confirmation { 'password' }

--- a/spec/requests/offers_request_spec.rb
+++ b/spec/requests/offers_request_spec.rb
@@ -55,23 +55,23 @@ RSpec.describe "Offers", type: :request do
     end
 
     context "ログインしており既存の案件で申請する場合" do
-      let(:offering_proposition_id) { offering.id }
+      let(:offering_id) { offering.id }
 
       before do
         sign_in user
       end
 
       it "リクエストが成功すること" do
-        post proposition_offers_path(offered.id), params: { offering_id: offering_proposition_id }
+        post proposition_offers_path(offered.id), params: { offering_proposition_id: offering_id }
         expect(response).to have_http_status "302"
       end
       it "申請の登録が成功すること" do
         expect do
-          post proposition_offers_path(offered.id), params: { offering_id: offering_proposition_id }
+          post proposition_offers_path(offered.id), params: { offering_proposition_id: offering_id }
         end.to change(Offer, :count).by(1)
       end
       it "案件詳細ページへリダイレクトすること" do
-        post proposition_offers_path(offered.id), params: { offering_id: offering_proposition_id }
+        post proposition_offers_path(offered.id), params: { offering_proposition_id: offering_id }
         expect(response).to redirect_to proposition_path(offered.id)
       end
     end

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Header", type: :system do
       end
       it "ログアウトリンクが表示される。" do
         click_on "ログアウト"
-        expect(current_path).to eq root_path
+        expect(page).to have_content 'ログアウトしました。'
       end
     end
   end


### PR DESCRIPTION
・factory_botのuserについて、user_statusがランダムになっておりテストに支障が出ていたので修正
・ログアウトリンクについて、ログアウトをフラッシュメッセージの表示で判定するよう修正

併せて
・offers_request.rbについて、paramsのkeyを誤っていたため修正。
・config/deploy.rbについて、githubのユーザー名を変更したので修正